### PR TITLE
Add ec2.metadata_url config option

### DIFF
--- a/bootconfig_yum_ansible.yaml
+++ b/bootconfig_yum_ansible.yaml
@@ -73,6 +73,13 @@ resources:
             {{/metadata_url}}
             {{/request}}
 
+            {{#ec2}}
+            [ec2]
+            {{#metadata_url}}
+            metadata_url = {{metadata_url}}
+            {{/metadata_url}}
+            {{/ec2}}
+
             {{/os-collect-config}}
         - path: /usr/libexec/os-apply-config/templates/var/run/heat-config/heat-config
           content: |


### PR DESCRIPTION
To keep os-collect-config from taking 2 minutes to timeout when polling
169.254.169.254.
